### PR TITLE
Add an attribute to allow passing excessive arguments to the command

### DIFF
--- a/Source/Arguments.php
+++ b/Source/Arguments.php
@@ -104,6 +104,19 @@ class Arguments
         };
     }
 
+    /**
+     * Takes any remaining items.
+     *
+     * @return array
+     */
+    public function take_all(): array
+    {
+        $temp = $this->arguments;
+        $this->arguments = [];
+
+        return $temp;
+    }
+
     private function take_option_as_array(CommandParameter $parameter)
     {
         return reduce($this->arguments, function ($options, $argument, $index) use ($parameter) {
@@ -237,13 +250,5 @@ class Arguments
         $this->use(first_key($this->arguments));
 
         return $value;
-    }
-
-    private function take_all(): array
-    {
-        $temp = $this->arguments;
-        $this->arguments = [];
-
-        return $temp;
     }
 }

--- a/Source/Attributes/ExcessiveArguments.php
+++ b/Source/Attributes/ExcessiveArguments.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpRepos\Console\Attributes;
+
+use Attribute;
+
+/**
+ * Excessive Arguments attribute for passing remaining arguments as an array to the command.
+ *
+ * This attribute is used to define a variable as the variable to pass any excessive arguments
+ * passed to the command.
+ * Note: The correspond variable must always be an array.
+ *
+ * Usage example:
+ * ```
+ * #[ExcessiveArguments]
+ * ```
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class ExcessiveArguments
+{
+
+}

--- a/Source/CommandParameter.php
+++ b/Source/CommandParameter.php
@@ -3,6 +3,7 @@
 namespace PhpRepos\Console;
 
 use PhpRepos\Console\Attributes\Argument;
+use PhpRepos\Console\Attributes\ExcessiveArguments;
 use PhpRepos\Console\Attributes\LongOption;
 use PhpRepos\Console\Attributes\Description;
 use PhpRepos\Console\Attributes\ShortOption;
@@ -23,16 +24,17 @@ class CommandParameter
     /**
      * Constructor for the CommandParameter class.
      *
-     * @param string      $name             The name of the parameter.
-     * @param bool        $is_optional      Indicates if the parameter is optional.
-     * @param bool        $accepts_argument Indicates if the parameter accepts an argument.
-     * @param string      $type             The data type of the parameter.
-     * @param string      $option_class     The class representing the option, if applicable.
-     * @param bool        $is_option        Indicates if the parameter is an option.
-     * @param null|string $short_option     The short option flag, if defined.
-     * @param null|string $long_option      The long option flag, if defined.
-     * @param null|string $description      A description of the parameter, if available.
-     * @param mixed       $default_value    The default value of the parameter, if available.
+     * @param string      $name                      The name of the parameter.
+     * @param bool        $is_optional               Indicates if the parameter is optional.
+     * @param bool        $accepts_argument          Indicates if the parameter accepts an argument.
+     * @param string      $type                      The data type of the parameter.
+     * @param string      $option_class              The class representing the option, if applicable.
+     * @param bool        $is_option                 Indicates if the parameter is an option.
+     * @param bool        $wants_excessive_arguments Indicates if the parameter has been defined to get excessive arguments
+     * @param null|string $short_option              The short option flag, if defined.
+     * @param null|string $long_option               The long option flag, if defined.
+     * @param null|string $description               A description of the parameter, if available.
+     * @param mixed       $default_value             The default value of the parameter, if available.
      */
     public function __construct(
         public readonly string  $name,
@@ -41,6 +43,7 @@ class CommandParameter
         public readonly string  $type,
         public readonly string  $option_class,
         public readonly bool    $is_option,
+        public readonly bool    $wants_excessive_arguments,
         public readonly ?string $short_option,
         public readonly ?string $long_option,
         public readonly ?string $description,
@@ -71,8 +74,9 @@ class CommandParameter
         $short_option = attribute_property($param, ShortOption::class, 'option');
         $long_option = attribute_property($param, LongOption::class, 'option');
         $accepts_argument = has_attribute($param, Argument::class);
+        $wants_excessive_arguments = has_attribute($param, ExcessiveArguments::class);
 
-        if (! $short_option && ! $long_option && ! $accepts_argument) {
+        if (! $short_option && ! $long_option && ! $accepts_argument && ! $wants_excessive_arguments) {
             throw new InvalidCommandDefinitionException('No option or argument has been defined.');
         }
 
@@ -83,6 +87,7 @@ class CommandParameter
             type: $param->getType()->getName(),
             option_class: $param->getType()->getName(),
             is_option: $short_option || $long_option,
+            wants_excessive_arguments: $wants_excessive_arguments,
             short_option: $short_option,
             long_option: $long_option,
             description: attribute_property($param, Description::class, 'description'),

--- a/Tests/ConsoleHelpTest.php
+++ b/Tests/ConsoleHelpTest.php
@@ -38,6 +38,7 @@ test(
                <command> [<options>] [<args>]
 
 Here you can see a list of available commands:
+\e[39m    accept-excessive-arguments
 \e[39m    default-bool-argument
 \e[39m    default-string-argument
 \e[39m    first
@@ -83,6 +84,7 @@ test(
                <command> [<options>] [<args>]
 
 Here you can see a list of available commands:
+\e[39m    accept-excessive-arguments
 \e[39m    default-bool-argument
 \e[39m    default-string-argument
 \e[39m    first
@@ -516,6 +518,34 @@ This command does not accept any options.
 EOD;
 
         assert_true($expected === $output, 'needs-bool-argument command\'s help did not get shown!' . PHP_EOL . $expected . PHP_EOL . $output);
+    },
+    before: function () {
+        copy_commands();
+    },
+    after: function () {
+        delete_commands();
+    }
+);
+
+test(
+    title: 'it should not show the defined variable for excessive arguments',
+    case: function () {
+        $output = help('accept-excessive-arguments');
+        $expected = <<<EOD
+\e[39mUsage: console accept-excessive-arguments [<options>]
+
+Description:
+No description provided for the command.
+
+Arguments:
+This command does not accept any arguments.
+
+Options:
+  --email <email> The email option for the command
+
+EOD;
+
+        assert_true($expected === $output, 'accept-excessive-arguments command\'s help did not get shown!' . PHP_EOL . $expected . PHP_EOL . $output);
     },
     before: function () {
         copy_commands();

--- a/Tests/ConsoleTest.php
+++ b/Tests/ConsoleTest.php
@@ -62,6 +62,7 @@ test(
                <command> [<options>] [<args>]
 
 Here you can see a list of available commands:
+\e[39m    accept-excessive-arguments
 \e[39m    default-bool-argument
 \e[39m    default-string-argument
 \e[39m    first
@@ -709,6 +710,21 @@ Options:
 EOD;
 
         assert_true($expected === $output, 'Wrong error message when extra argument passed.' . PHP_EOL . $expected . PHP_EOL . $output);
+    },
+    before: function () {
+        copy_commands();
+    },
+    after: function () {
+        delete_commands();
+    }
+);
+
+test(
+    title: 'it should pass excessive arguments to the command when there is a variable defined for accepting them',
+    case: function () {
+        $output = run('accept-excessive-arguments --email=info@phpkg.com --password=secret john -l -p');
+
+        assert_line('--password=secretjohn-l-p', $output);
     },
     before: function () {
         copy_commands();

--- a/Tests/HelperCommands/AcceptExcessiveArgumentsCommand.php
+++ b/Tests/HelperCommands/AcceptExcessiveArgumentsCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+use PhpRepos\Console\Attributes\Description;
+use PhpRepos\Console\Attributes\ExcessiveArguments;
+use PhpRepos\Console\Attributes\LongOption;
+use function PhpRepos\Cli\Output\line;
+
+return function(
+    #[LongOption('email')]
+    #[Description('The email option for the command')]
+    string $email,
+    #[ExcessiveArguments]
+    array $remaining,
+) {
+    line(implode('', $remaining));
+};


### PR DESCRIPTION
This PR allows the user to pass excessive arguments to the command to let developers handle it instead of showing an error.

