### PR TITLE
Remove test runner from dependencies

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [8.2, 8.1]
+        php: [8.3, 8.2, 8.1]
 
     name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Execute tests
         run: |
           cd builds/production
-          php test-runner
+          phpkg run https://github.com/php-repos/test-runner.git

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Execute tests
         run: |
           cd builds/production
-          phpkg run https://github.com/php-repos/test-runner.git
+          ~/.phpkg/phpkg run https://github.com/php-repos/test-runner.git

--- a/Tests/ConsoleHelpTest.php
+++ b/Tests/ConsoleHelpTest.php
@@ -3,7 +3,7 @@
 namespace Tests\ConsoleHelpTest;
 
 use function PhpRepos\Cli\Output\assert_error;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 use function Tests\Helper\copy_commands;
 use function Tests\Helper\delete_commands;

--- a/Tests/ConsoleTest.php
+++ b/Tests/ConsoleTest.php
@@ -4,7 +4,7 @@ namespace Tests\ConsoleTest;
 
 use function PhpRepos\Cli\Output\assert_error;
 use function PhpRepos\Cli\Output\assert_line;
-use function PhpRepos\TestRunner\Assertions\Boolean\assert_true;
+use function PhpRepos\TestRunner\Assertions\assert_true;
 use function PhpRepos\TestRunner\Runner\test;
 use function Tests\Helper\copy_commands;
 use function Tests\Helper\delete_commands;

--- a/phpkg.config-lock.json
+++ b/phpkg.config-lock.json
@@ -3,26 +3,20 @@
         "https:\/\/github.com\/php-repos\/datatype.git": {
             "owner": "php-repos",
             "repo": "datatype",
-            "version": "v1.1.0",
-            "hash": "3b068db2d678d9a2eb803951cc602ad6a09fbee9"
+            "version": "v2.0.0",
+            "hash": "7fe3a27e6b57ff31374927d14c63db07cbaee579"
         },
         "https:\/\/github.com\/php-repos\/file-manager.git": {
             "owner": "php-repos",
             "repo": "file-manager",
-            "version": "v2.0.3",
-            "hash": "a03298b28f31192acf682b0dd015e3bb1aef307b"
+            "version": "v3.0.0",
+            "hash": "f6b8aef10d56cd7c8d2f87a23c267d7d79c73b92"
         },
         "https:\/\/github.com\/php-repos\/cli.git": {
             "owner": "php-repos",
             "repo": "cli",
-            "version": "v2.0.0",
-            "hash": "f4445518f45bc4161037532298b509bc7fb071bd"
-        },
-        "https:\/\/github.com\/php-repos\/test-runner.git": {
-            "owner": "php-repos",
-            "repo": "test-runner",
-            "version": "v1.2.0",
-            "hash": "3b6df8cd914747d1317840155f5b4ed73c441250"
+            "version": "v3.0.1",
+            "hash": "6073fb50f047f10129fc0926293d44f0c31b1d56"
         }
     }
 }

--- a/phpkg.config.json
+++ b/phpkg.config.json
@@ -3,22 +3,22 @@
         "PhpRepos\\Console": "Source",
         "Tests": "Tests"
     },
+    "autoloads": [],
+    "excludes": [],
     "entry-points": [
         "console"
     ],
-    "excludes": [],
     "executables": {
         "console": "console"
     },
+    "import-file": "phpkg.imports.php",
     "packages-directory": "Packages",
     "packages": {
-        "https:\/\/github.com\/php-repos\/file-manager.git": "v2.0.3",
-        "https:\/\/github.com\/php-repos\/datatype.git": "v1.1.0",
-        "https:\/\/github.com\/php-repos\/test-runner.git": "v1.2.0",
-        "https:\/\/github.com\/php-repos\/cli.git": "v2.0.0"
+        "https:\/\/github.com\/php-repos\/file-manager.git": "v3.0.0",
+        "https:\/\/github.com\/php-repos\/datatype.git": "v2.0.0",
+        "https:\/\/github.com\/php-repos\/cli.git": "v3.0.1"
     },
     "aliases": {
-        "test-runner": "https:\/\/github.com\/php-repos\/test-runner.git",
         "file-manager": "https:\/\/github.com\/php-repos\/file-manager.git",
         "datatype": "https:\/\/github.com\/php-repos\/datatype.git",
         "cli": "https:\/\/github.com\/php-repos\/cli.git"


### PR DESCRIPTION
This PR removes the `test-runner` from dependencies and updates all used packages to their latest updates.